### PR TITLE
Remove fix for memery leak as it's now handle in the fty-commomn-dto

### DIFF
--- a/src/fty_srr_selftest.cc
+++ b/src/fty_srr_selftest.cc
@@ -1,6 +1,3 @@
-//Note: This is file has been customized in 2 sections (headers and end of the file)
-//      to avoid memory leak detection from protobuf
-
 /*  =========================================================================
     fty_srr_selftest.c - run selftests
 
@@ -31,9 +28,6 @@
 */
 
 #include "fty_srr_classes.h"
-
-//Note: This is to avoid memory leak detection from protobuf
-#include <google/protobuf/util/json_util.h>
 
 typedef struct {
     const char *testname;           // test name, can be called from command line this way
@@ -189,8 +183,6 @@ main (int argc, char **argv)
     else
         test_runall (verbose);
 
-//Note: This is to avoid memory leak detection from protobuf
-    google::protobuf::ShutdownProtobufLibrary();
     return 0;
 }
 /*


### PR DESCRIPTION
Signed-off-by: Clement Perrette <clementperrette@eaton.com>