### PR TITLE
Remove dep from etn-licensing

### DIFF
--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -24,7 +24,6 @@ Maintainer:     fty-srr Developers <eatonipcopensource@eaton.com>
 Standards-Version: 4.0.1.0
 Build-Depends: debhelper (>= 9),
     pkg-config,
-    etn-licensing,
     fty-cmake-dev,
     libfty-common-logging-dev,
     libcxxtools-dev,
@@ -44,7 +43,7 @@ Build-Depends: debhelper (>= 9),
 
 Package: fty-srr
 Architecture: any
-Depends: ${misc:Depends}, ${shlibs:Depends},
+Depends: ${misc:Depends}, ${shlibs:Depends}, etn-licensing
 Description: runnable binaries from fty-srr
  Main package for fty-srr:
  save, restore and reset agent for 42ity ecosystem

--- a/server/src/fty_srr_worker.cc
+++ b/server/src/fty_srr_worker.cc
@@ -39,7 +39,6 @@
 #include "helpers/data_integrity.h"
 #include "helpers/utils.h"
 
-#include <etn/licensing/capabilities.h>
 #include <fty_common.h>
 #include <fty_common_mlm.h>
 #include <fty_lib_certificate_library.h>
@@ -50,6 +49,9 @@
 #include <numeric>
 #include <vector>
 #include <thread>
+#include <iostream>
+#include <string>
+#include <sstream>
 
 #define SRR_RESTART_DELAY_SEC     5
 #define FEATURE_RESTORE_DELAY_SEC 6
@@ -449,6 +451,7 @@ namespace srr
 
         zmsg_t *req = zmsg_new ();
         zmsg_addstr(req, "CAPABILITIES");
+        zmsg_addstr(req, "configurability");
 
         zmsg_t *resp = client->requestreply ("etn-licensing", "licensing", 5, &req);
         if (!resp)
@@ -473,13 +476,14 @@ namespace srr
             return false;
         }
 
-        std::string capabilitiesJson = zmsg_popstring (resp);
+        std::string configurabilityStr = zmsg_popstring (resp);
         zmsg_destroy (&resp);
 
-        Capabilities cap;
-        pack::json::deserialize(capabilitiesJson, cap);
+        bool configurability;
 
-        return cap.configurability;
+        std::istringstream(configurabilityStr) >> configurability;
+
+        return configurability;
     }
 
     dto::UserData SrrWorker::requestRestore(const std::string& json, bool force)


### PR DESCRIPTION
- request configurability directly to licensing agent

Signed-off-by: Mauro Guerrera <mauroguerrera@eaton.com>