### PR TITLE
IPMPROG-4347 - Upgrade payload fmt version from 2.1 to 2.2

### DIFF
--- a/server/resources/fty-srr.cfg
+++ b/server/resources/fty-srr.cfg
@@ -12,5 +12,5 @@ srr-msg-bus
     srrQueueName = ETN.Q.IPMCORE.SRR        # Srr queue name for all incoming request.
 
 srr
-    version = 2.1        # Srr version
+    version = 2.2        # Srr version
     enableReboot = true  # Enable/disable reboot after restore

--- a/server/src/dto/request.h
+++ b/server/src/dto/request.h
@@ -27,8 +27,8 @@
 
 //see SRR_VERSION_ALL SRR_ACTIVE_VERSION
 //std::string version, X.Y format (major/minor)
-#define IS_VERSION_1(version) (!version.empty() && (version[0] == '1'))
-#define IS_VERSION_2(version) (!version.empty() && (version[0] == '2'))
+#define IS_VERSION_1(version) (version.find("1.") == 0)
+#define IS_VERSION_2(version) (version.find("2.") == 0)
 
 namespace srr {
 // si save request fields

--- a/server/src/dto/request.h
+++ b/server/src/dto/request.h
@@ -26,9 +26,9 @@
 #include <vector>
 
 //see SRR_VERSION_ALL SRR_ACTIVE_VERSION
-//std::string version
-#define IS_VERSION_1(version) (version == "1.0")
-#define IS_VERSION_2(version) ((version == "2.0") || (version == "2.1"))
+//std::string version, X.Y format (major/minor)
+#define IS_VERSION_1(version) (!version.empty() && (version[0] == '1'))
+#define IS_VERSION_2(version) (!version.empty() && (version[0] == '2'))
 
 namespace srr {
 // si save request fields

--- a/server/src/fty-srr.h
+++ b/server/src/fty-srr.h
@@ -37,13 +37,13 @@ constexpr auto REQUEST_TIMEOUT_DEFAULT   = "600000"; //ms
 constexpr auto AGENT_NAME                = "fty-srr";
 constexpr auto DEFAULT_ENDPOINT          = "ipc://@/malamute";
 constexpr auto SRR_MSG_QUEUE_NAME        = "ETN.Q.IPMCORE.SRR";
-constexpr auto SRR_ACTIVE_VERSION        = "2.1";
+constexpr auto SRR_ACTIVE_VERSION        = "2.2";
 constexpr auto SRR_ENABLE_REBOOT_DEFAULT = "true";
 constexpr auto SRR_PREFIX_TRANSLATE_KEY  = "srr_";
 
 //set of all released versions
 //see SRR_ACTIVE_VERSION IS_VERSION_1 IS_VERSION_2
-const auto SRR_VERSION_ALL{std::set<std::string>({"1.0", "2.0", "2.1"})};
+const auto SRR_VERSION_ALL{std::set<std::string>({"1.0", "2.0", "2.1", "2.2"})};
 
 // AGENTS AND QUEUES
 // Config agent definition
@@ -93,8 +93,8 @@ constexpr auto F_DISCOVERY                            = "discovery";
 constexpr auto F_MASS_MANAGEMENT                      = "etn-mass-management";
 constexpr auto F_MONITORING_FEATURE_NAME              = "monitoring";
 constexpr auto F_NETWORK                              = "network";
-constexpr auto F_NETWORK_AGENT_SETTINGS               = "network-agent-settings";
 constexpr auto F_NETWORK_HOST_NAME                    = "network-host-name";
+constexpr auto F_NETWORK_AGENT_SETTINGS               = "network-agent-settings";
 constexpr auto F_NOTIFICATION_FEATURE_NAME            = "notification";
 constexpr auto F_RSYSLOG_FEATURE_NAME                 = "rsyslog";
 constexpr auto F_SECURITY_WALLET                      = "security-wallet";

--- a/server/src/fty_srr_groups.cc
+++ b/server/src/fty_srr_groups.cc
@@ -71,7 +71,7 @@ static auto initSrrFeatures = []() {
     tmp[F_ALERT_AGENT].m_name        = F_ALERT_AGENT;
     tmp[F_ALERT_AGENT].m_description = TRANSLATE_ME("srr_alert-agent");
     tmp[F_ALERT_AGENT].m_agent       = ALERT_AGENT_NAME;
-    tmp[F_ALERT_AGENT].m_requiredIn  = {"1.0", "2.0", "2.1"};
+    tmp[F_ALERT_AGENT].m_requiredIn  = {"1.0", "2.0", "2.1", "2.2"};
     tmp[F_ALERT_AGENT].m_restart     = true;
     tmp[F_ALERT_AGENT].m_reset       = true;
 
@@ -80,7 +80,7 @@ static auto initSrrFeatures = []() {
     tmp[F_ASSET_AGENT].m_name        = F_ASSET_AGENT;
     tmp[F_ASSET_AGENT].m_description = TRANSLATE_ME("srr_asset-agent");
     tmp[F_ASSET_AGENT].m_agent       = ASSET_AGENT_NAME;
-    tmp[F_ASSET_AGENT].m_requiredIn  = {"1.0", "2.0", "2.1"};
+    tmp[F_ASSET_AGENT].m_requiredIn  = {"1.0", "2.0", "2.1", "2.2"};
     tmp[F_ASSET_AGENT].m_restart     = true;
     tmp[F_ASSET_AGENT].m_reset       = true;
 
@@ -89,7 +89,7 @@ static auto initSrrFeatures = []() {
     tmp[F_AUTOMATIC_GROUPS].m_name        = F_AUTOMATIC_GROUPS;
     tmp[F_AUTOMATIC_GROUPS].m_description = TRANSLATE_ME("srr_automatic-groups");
     tmp[F_AUTOMATIC_GROUPS].m_agent       = AUTOMATIC_GROUPS_NAME;
-    tmp[F_AUTOMATIC_GROUPS].m_requiredIn  = {"2.1"};
+    tmp[F_AUTOMATIC_GROUPS].m_requiredIn  = {"2.1", "2.2"};
     tmp[F_AUTOMATIC_GROUPS].m_restart     = true;
     tmp[F_AUTOMATIC_GROUPS].m_reset       = true;
 
@@ -98,7 +98,7 @@ static auto initSrrFeatures = []() {
     tmp[F_AUTOMATION_SETTINGS].m_name        = F_AUTOMATION_SETTINGS;
     tmp[F_AUTOMATION_SETTINGS].m_description = TRANSLATE_ME("srr_automation-settings");
     tmp[F_AUTOMATION_SETTINGS].m_agent       = CONFIG_AGENT_NAME;
-    tmp[F_AUTOMATION_SETTINGS].m_requiredIn  = {"1.0", "2.0", "2.1"};
+    tmp[F_AUTOMATION_SETTINGS].m_requiredIn  = {"1.0", "2.0", "2.1", "2.2"};
     tmp[F_AUTOMATION_SETTINGS].m_restart     = true;
     tmp[F_AUTOMATION_SETTINGS].m_reset       = false;
 
@@ -107,7 +107,7 @@ static auto initSrrFeatures = []() {
     tmp[F_AUTOMATIONS].m_name        = F_AUTOMATIONS;
     tmp[F_AUTOMATIONS].m_description = TRANSLATE_ME("srr_automations");
     tmp[F_AUTOMATIONS].m_agent       = EMC4J_AGENT_NAME;
-    tmp[F_AUTOMATIONS].m_requiredIn  = {"1.0", "2.0", "2.1"};
+    tmp[F_AUTOMATIONS].m_requiredIn  = {"1.0", "2.0", "2.1", "2.2"};
     tmp[F_AUTOMATIONS].m_restart     = true;
     tmp[F_AUTOMATIONS].m_reset       = true;
 
@@ -116,7 +116,7 @@ static auto initSrrFeatures = []() {
     tmp[F_DISCOVERY].m_name        = F_DISCOVERY;
     tmp[F_DISCOVERY].m_description = TRANSLATE_ME("srr_discovery");
     tmp[F_DISCOVERY].m_agent       = CONFIG_AGENT_NAME;
-    tmp[F_DISCOVERY].m_requiredIn  = {"1.0", "2.0", "2.1"};
+    tmp[F_DISCOVERY].m_requiredIn  = {"1.0", "2.0", "2.1", "2.2"};
     tmp[F_DISCOVERY].m_restart     = true;
     tmp[F_DISCOVERY].m_reset       = false;
 
@@ -125,7 +125,7 @@ static auto initSrrFeatures = []() {
     tmp[F_MASS_MANAGEMENT].m_name        = F_MASS_MANAGEMENT;
     tmp[F_MASS_MANAGEMENT].m_description = TRANSLATE_ME("srr_etn-mass-management");
     tmp[F_MASS_MANAGEMENT].m_agent       = CONFIG_AGENT_NAME;
-    tmp[F_MASS_MANAGEMENT].m_requiredIn  = {"1.0", "2.0", "2.1"};
+    tmp[F_MASS_MANAGEMENT].m_requiredIn  = {"1.0", "2.0", "2.1", "2.2"};
     tmp[F_MASS_MANAGEMENT].m_restart     = true;
     tmp[F_MASS_MANAGEMENT].m_reset       = false;
 
@@ -134,7 +134,7 @@ static auto initSrrFeatures = []() {
     tmp[F_MONITORING_FEATURE_NAME].m_name        = F_MONITORING_FEATURE_NAME;
     tmp[F_MONITORING_FEATURE_NAME].m_description = TRANSLATE_ME("srr_monitoring");
     tmp[F_MONITORING_FEATURE_NAME].m_agent       = CONFIG_AGENT_NAME;
-    tmp[F_MONITORING_FEATURE_NAME].m_requiredIn  = {"1.0", "2.0", "2.1"};
+    tmp[F_MONITORING_FEATURE_NAME].m_requiredIn  = {"1.0", "2.0", "2.1", "2.2"};
     tmp[F_MONITORING_FEATURE_NAME].m_restart     = true;
     tmp[F_MONITORING_FEATURE_NAME].m_reset       = false;
 
@@ -143,34 +143,34 @@ static auto initSrrFeatures = []() {
     tmp[F_NETWORK].m_name        = F_NETWORK;
     tmp[F_NETWORK].m_description = TRANSLATE_ME("srr_network");
     tmp[F_NETWORK].m_agent       = CONFIG_AGENT_NAME;
-    tmp[F_NETWORK].m_requiredIn  = {"1.0", "2.0", "2.1"};
+    tmp[F_NETWORK].m_requiredIn  = {"1.0", "2.0", "2.1", "2.2"};
     tmp[F_NETWORK].m_restart     = true;
     tmp[F_NETWORK].m_reset       = false;
-
-    tmp[F_NETWORK_AGENT_SETTINGS];
-    tmp[F_NETWORK_AGENT_SETTINGS].m_id          = F_NETWORK_AGENT_SETTINGS;
-    tmp[F_NETWORK_AGENT_SETTINGS].m_name        = F_NETWORK_AGENT_SETTINGS;
-    tmp[F_NETWORK_AGENT_SETTINGS].m_description = TRANSLATE_ME("srr_network-agent-settings");
-    tmp[F_NETWORK_AGENT_SETTINGS].m_agent       = CONFIG_AGENT_NAME;
-    tmp[F_NETWORK_AGENT_SETTINGS].m_requiredIn  = {"1.0", "2.0", "2.1"};
-    tmp[F_NETWORK_AGENT_SETTINGS].m_restart     = true;
-    tmp[F_NETWORK_AGENT_SETTINGS].m_reset       = false;
 
     tmp[F_NETWORK_HOST_NAME];
     tmp[F_NETWORK_HOST_NAME].m_id          = F_NETWORK_HOST_NAME;
     tmp[F_NETWORK_HOST_NAME].m_name        = F_NETWORK_HOST_NAME;
     tmp[F_NETWORK_HOST_NAME].m_description = TRANSLATE_ME("srr_network-host-name");
     tmp[F_NETWORK_HOST_NAME].m_agent       = CONFIG_AGENT_NAME;
-    tmp[F_NETWORK_HOST_NAME].m_requiredIn  = {"1.0", "2.0", "2.1"};
+    tmp[F_NETWORK_HOST_NAME].m_requiredIn  = {"2.2"};
     tmp[F_NETWORK_HOST_NAME].m_restart     = true;
     tmp[F_NETWORK_HOST_NAME].m_reset       = false;
+
+    tmp[F_NETWORK_AGENT_SETTINGS];
+    tmp[F_NETWORK_AGENT_SETTINGS].m_id          = F_NETWORK_AGENT_SETTINGS;
+    tmp[F_NETWORK_AGENT_SETTINGS].m_name        = F_NETWORK_AGENT_SETTINGS;
+    tmp[F_NETWORK_AGENT_SETTINGS].m_description = TRANSLATE_ME("srr_network-agent-settings");
+    tmp[F_NETWORK_AGENT_SETTINGS].m_agent       = CONFIG_AGENT_NAME;
+    tmp[F_NETWORK_AGENT_SETTINGS].m_requiredIn  = {"2.2"};
+    tmp[F_NETWORK_AGENT_SETTINGS].m_restart     = true;
+    tmp[F_NETWORK_AGENT_SETTINGS].m_reset       = false;
 
     tmp[F_NOTIFICATION_FEATURE_NAME];
     tmp[F_NOTIFICATION_FEATURE_NAME].m_id          = F_NOTIFICATION_FEATURE_NAME;
     tmp[F_NOTIFICATION_FEATURE_NAME].m_name        = F_NOTIFICATION_FEATURE_NAME;
     tmp[F_NOTIFICATION_FEATURE_NAME].m_description = TRANSLATE_ME("srr_notification");
     tmp[F_NOTIFICATION_FEATURE_NAME].m_agent       = CONFIG_AGENT_NAME;
-    tmp[F_NOTIFICATION_FEATURE_NAME].m_requiredIn  = {"1.0", "2.0", "2.1"};
+    tmp[F_NOTIFICATION_FEATURE_NAME].m_requiredIn  = {"1.0", "2.0", "2.1", "2.2"};
     tmp[F_NOTIFICATION_FEATURE_NAME].m_restart     = true;
     tmp[F_NOTIFICATION_FEATURE_NAME].m_reset       = false;
 
@@ -179,7 +179,7 @@ static auto initSrrFeatures = []() {
     tmp[F_RSYSLOG_FEATURE_NAME].m_name        = F_RSYSLOG_FEATURE_NAME;
     tmp[F_RSYSLOG_FEATURE_NAME].m_description = TRANSLATE_ME("srr_rsyslog");
     tmp[F_RSYSLOG_FEATURE_NAME].m_agent       = RSYSLOG_AGENT_NAME;
-    tmp[F_RSYSLOG_FEATURE_NAME].m_requiredIn  = {"2.1"};
+    tmp[F_RSYSLOG_FEATURE_NAME].m_requiredIn  = {"2.1", "2.2"};
     tmp[F_RSYSLOG_FEATURE_NAME].m_restart     = true;
     tmp[F_RSYSLOG_FEATURE_NAME].m_reset       = true;
 
@@ -188,7 +188,7 @@ static auto initSrrFeatures = []() {
     tmp[F_SECURITY_WALLET].m_name        = F_SECURITY_WALLET;
     tmp[F_SECURITY_WALLET].m_description = TRANSLATE_ME("srr_security-wallet");
     tmp[F_SECURITY_WALLET].m_agent       = SECU_WALLET_AGENT_NAME;
-    tmp[F_SECURITY_WALLET].m_requiredIn  = {"1.0", "2.0", "2.1"};
+    tmp[F_SECURITY_WALLET].m_requiredIn  = {"1.0", "2.0", "2.1", "2.2"};
     tmp[F_SECURITY_WALLET].m_restart     = true;
     tmp[F_SECURITY_WALLET].m_reset       = false;
 
@@ -197,7 +197,7 @@ static auto initSrrFeatures = []() {
     tmp[F_USER_SESSION_MANAGEMENT_FEATURE_NAME].m_name        = F_USER_SESSION_MANAGEMENT_FEATURE_NAME;
     tmp[F_USER_SESSION_MANAGEMENT_FEATURE_NAME].m_description = TRANSLATE_ME("srr_user-session-management");
     tmp[F_USER_SESSION_MANAGEMENT_FEATURE_NAME].m_agent       = USM_AGENT_NAME;
-    tmp[F_USER_SESSION_MANAGEMENT_FEATURE_NAME].m_requiredIn  = {"2.1"};
+    tmp[F_USER_SESSION_MANAGEMENT_FEATURE_NAME].m_requiredIn  = {"2.1", "2.2"};
     tmp[F_USER_SESSION_MANAGEMENT_FEATURE_NAME].m_restart     = true;
     tmp[F_USER_SESSION_MANAGEMENT_FEATURE_NAME].m_reset       = false;
 
@@ -206,7 +206,7 @@ static auto initSrrFeatures = []() {
     tmp[F_VIRTUAL_ASSETS].m_name        = F_VIRTUAL_ASSETS;
     tmp[F_VIRTUAL_ASSETS].m_description = TRANSLATE_ME("srr_virtual-assets");
     tmp[F_VIRTUAL_ASSETS].m_agent       = EMC4J_AGENT_NAME;
-    tmp[F_VIRTUAL_ASSETS].m_requiredIn  = {"1.0", "2.0", "2.1"};
+    tmp[F_VIRTUAL_ASSETS].m_requiredIn  = {"1.0", "2.0", "2.1", "2.2"};
     tmp[F_VIRTUAL_ASSETS].m_restart     = true;
     tmp[F_VIRTUAL_ASSETS].m_reset       = true;
 
@@ -215,7 +215,7 @@ static auto initSrrFeatures = []() {
     tmp[F_VIRTUALIZATION_SETTINGS].m_name        = F_VIRTUALIZATION_SETTINGS;
     tmp[F_VIRTUALIZATION_SETTINGS].m_description = TRANSLATE_ME("srr_virtualization-settings");
     tmp[F_VIRTUALIZATION_SETTINGS].m_agent       = EMC4J_AGENT_NAME;
-    tmp[F_VIRTUALIZATION_SETTINGS].m_requiredIn  = {"2.1"};
+    tmp[F_VIRTUALIZATION_SETTINGS].m_requiredIn  = {"2.1", "2.2"};
     tmp[F_VIRTUALIZATION_SETTINGS].m_restart     = true;
     tmp[F_VIRTUALIZATION_SETTINGS].m_reset       = true;
 
@@ -224,7 +224,7 @@ static auto initSrrFeatures = []() {
     tmp[F_AI_SETTINGS].m_name        = F_AI_SETTINGS;
     tmp[F_AI_SETTINGS].m_description = TRANSLATE_ME("srr_ai-settings");
     tmp[F_AI_SETTINGS].m_agent       = EMC4J_AGENT_NAME;
-    tmp[F_AI_SETTINGS].m_requiredIn  = {"2.1"};
+    tmp[F_AI_SETTINGS].m_requiredIn  = {"2.1", "2.2"};
     tmp[F_AI_SETTINGS].m_restart     = true;
     tmp[F_AI_SETTINGS].m_reset       = true;
 
@@ -299,8 +299,8 @@ static auto initSrrGroups = []() {
     tmp[G_NETWORK].m_restoreOrder = restoreOrder++;
 
     tmp[G_NETWORK].m_fp.push_back(SrrFeaturePriorityStruct(F_NETWORK, 1));
-    tmp[G_NETWORK].m_fp.push_back(SrrFeaturePriorityStruct(F_NETWORK_AGENT_SETTINGS, 2));
-    tmp[G_NETWORK].m_fp.push_back(SrrFeaturePriorityStruct(F_NETWORK_HOST_NAME, 3));
+    tmp[G_NETWORK].m_fp.push_back(SrrFeaturePriorityStruct(F_NETWORK_HOST_NAME, 2));
+    tmp[G_NETWORK].m_fp.push_back(SrrFeaturePriorityStruct(F_NETWORK_AGENT_SETTINGS, 3));
 
     // add features to notification feature group
     tmp[G_NOTIFICATION].m_id           = G_NOTIFICATION;


### PR DESCRIPTION
Note: this is required to support Restore from previous IPM versions

* upgrade format version to 2.2
Signed-off-by: Degott, Francois Regis <FrancoisRegisDegott@eaton.com>