### PR TITLE
Fix 2.6 build256

### DIFF
--- a/server/src/fty_srr_worker.cc
+++ b/server/src/fty_srr_worker.cc
@@ -102,20 +102,22 @@ dto::srr::SaveResponse SrrWorker::saveFeature(
     // Send message to agent
     messagebus::Message message;
     try {
-        message = sendRequest(m_msgBus, data, "save", m_parameters.at(AGENT_NAME_KEY), queueNameDest, agentNameDest);
+        message = sendRequest(m_msgBus, data, "save", m_parameters.at(AGENT_NAME_KEY), queueNameDest, agentNameDest, m_sendTimeout_s);
     } catch (SrrException& ex) {
         logError("Request save of feature {} by agent {}/{} has failed (e: {})", featureName, agentNameDest, queueNameDest, ex.what());
         throw(SrrSaveFailed("Request to agent " + agentNameDest + ":" + queueNameDest + " failed: " + ex.what()));
     }
 
     logDebug("Request save of {} done by agent {}", featureName, agentNameDest);
-    logDebug("response frames: {}", message.userData().size());
 
+/**
+    logDebug("response frames: {}", message.userData().size());
     if (ftylog_getInstance()->isLogDebug()) { //dump response frames
         int i = 0;
         for (auto& s : message.userData())
             { logDebug("frame #{}: {}", i, s); i++; }
     }
+**/
 
     dto::srr::Response featureResponse;
     message.userData() >> featureResponse;

--- a/server/src/helpers/data_integrity.cc
+++ b/server/src/helpers/data_integrity.cc
@@ -47,6 +47,8 @@ std::string evalSha256(const std::string& data)
 
 void evalDataIntegrity(Group& group)
 {
+    logDebug("evalDataIntegrity group: {}", group.m_group_name);
+
     // sort features by priority (order can change)
     std::sort(group.m_features.begin(), group.m_features.end(), [&](SrrFeature l, SrrFeature r) {
         return getPriority(l.m_feature_name) < getPriority(r.m_feature_name);
@@ -58,10 +60,6 @@ void evalDataIntegrity(Group& group)
     const std::string data = dto::srr::serializeJson(tmpSi, false);
 
     group.m_data_integrity = evalSha256(data);
-
-    logDebug("evalDataIntegrity group: {}", group.m_group_name);
-    logDebug("evalDataIntegrity data: {}", data);
-    logDebug("evalDataIntegrity sha: {}", group.m_data_integrity);
 }
 
 bool checkDataIntegrity(const Group& group)

--- a/server/src/helpers/utils.cc
+++ b/server/src/helpers/utils.cc
@@ -90,8 +90,8 @@ messagebus::Message sendRequest(messagebus::MessageBus& msgbus, const dto::UserD
     }
 
     logDebug("Receive '{}' response from {}",
-        resp.metaData().at(messagebus::Message::SUBJECT).c_str(),
-        resp.metaData().at(messagebus::Message::FROM).c_str());
+        resp.metaData().at(messagebus::Message::SUBJECT),
+        resp.metaData().at(messagebus::Message::FROM));
 
     return resp;
 }


### PR DESCRIPTION
* fix crash on bad log format
* fix sendRequest() missing 'timeout'argument!
* remove dangerous/useless logs (huge strings)